### PR TITLE
Fix setup for development with ganache

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ deployed for free.
 
 Then:
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml build --force-rm
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+docker buildx bake -f docker-compose.yml -f docker-compose.dev.yml
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 ```
 
 The service should be running in `localhost:8000`

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,11 +10,12 @@ services:
     depends_on:
       - db
       - redis
+      - ganache
     working_dir: /app
     ports:
       - "8888:8888"
     volumes:
-      - nginx-shared:/nginx
+      - ./docker/nginx-shared:/nginx
     command: docker/web/run_web.sh
 
   worker: &worker
@@ -29,7 +30,7 @@ services:
     command: docker/web/celery/worker/run.sh
 
   ganache:
-    image: trufflesuite/ganache-cli
-    command: -d --defaultBalanceEther 10000 --gasLimit 10000000 -a 30 --chain.chainId 1337 --chain.networkId 1337
+    image: trufflesuite/ganache
+    command: -d --defaultBalanceEther 10000 --gasLimit 10000000 -a 30
     ports:
       - "8545:8545"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "8000:8000"
     volumes:
       - ./docker/nginx/safe_service.conf:/etc/nginx/nginx.conf:ro
-      - nginx-shared:/nginx
+      - ./docker/nginx-shared:/nginx
     depends_on:
       - web
 
@@ -40,7 +40,7 @@ services:
     ports:
       - "8888:8888"
     volumes:
-      - nginx-shared:/nginx
+      - ./docker/nginx-shared:/nginx
     command: docker/web/run_web.sh
 
   worker: &worker

--- a/docker/nginx-shared/.gitignore
+++ b/docker/nginx-shared/.gitignore
@@ -1,0 +1,6 @@
+# .gitignore sample
+# Ignore all files in this dir...
+*
+
+# ... except for this one.
+!.gitignore


### PR DESCRIPTION
The docker compose files were outdated.

Last month apparently the web3 dependency was updated to v5.28 which makes some changes to maxPriorityFeePerGas which were causing the used ganache-cli version to no longer work.
Web3 was making a eth_maxPriorityFeePerGas call that was failing against ganache v6 and thus we were no longer able to install the contracts.

The dockerhub image of ganache is no longer called ganache-cli, but ganache. By switching to trufflesuite/ganache we are installing ganache v7 where maxPriorityFeePerGas is available.

Also I was trying to build on a M1 but the built images were amd64. I updated the readme to reflect that docker can build multi-architecture images by using the buildx command.