### PR TITLE
update safe eth py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ psycogreen==1.0.2
 psycopg2==2.9.5
 redis==4.5.4
 requests==2.28.2
-safe-eth-py[django]==5.0.2
-web3==5.31.3
+safe-eth-py[django]==5.3.1
+web3==6.3.0

--- a/safe_relay_service/gas_station/gas_station.py
+++ b/safe_relay_service/gas_station/gas_station.py
@@ -169,17 +169,17 @@ class GasStation:
 class GasStationMock(GasStation):
     def __init__(self, gas_price: Optional[int] = None):
         if gas_price is None:
-            self.lowest = Web3.toWei(1, "gwei")
-            self.safe_low = Web3.toWei(5, "gwei")
-            self.standard = Web3.toWei(10, "gwei")
-            self.fast = Web3.toWei(20, "gwei")
-            self.fastest = Web3.toWei(50, "gwei")
+            self.lowest = Web3.to_wei(1, "gwei")
+            self.safe_low = Web3.to_wei(5, "gwei")
+            self.standard = Web3.to_wei(10, "gwei")
+            self.fast = Web3.to_wei(20, "gwei")
+            self.fastest = Web3.to_wei(50, "gwei")
         else:
-            self.lowest = Web3.toWei(gas_price, "gwei")
-            self.safe_low = Web3.toWei(gas_price + 1, "gwei")
-            self.standard = Web3.toWei(gas_price + 2, "gwei")
-            self.fast = Web3.toWei(gas_price + 3, "gwei")
-            self.fastest = Web3.toWei(gas_price + 4, "gwei")
+            self.lowest = Web3.to_wei(gas_price, "gwei")
+            self.safe_low = Web3.to_wei(gas_price + 1, "gwei")
+            self.standard = Web3.to_wei(gas_price + 2, "gwei")
+            self.fast = Web3.to_wei(gas_price + 3, "gwei")
+            self.fastest = Web3.to_wei(gas_price + 4, "gwei")
 
     def calculate_gas_prices(self) -> GasPrice:
         return GasPrice(

--- a/safe_relay_service/gas_station/tests/test_gas_station.py
+++ b/safe_relay_service/gas_station/tests/test_gas_station.py
@@ -22,7 +22,7 @@ class TestGasStation(TestCase):
 
         if w3.eth.block_number < number_of_blocks and w3.eth.accounts:  # Ganache
             # Mine some blocks
-            eth_balance = w3.toWei(0.00001, "ether")
+            eth_balance = w3.to_wei(0.00001, "ether")
             for _ in range(number_of_blocks - w3.eth.block_number + 2):
                 w3.eth.wait_for_transaction_receipt(
                     w3.eth.send_transaction(

--- a/safe_relay_service/relay/admin.py
+++ b/safe_relay_service/relay/admin.py
@@ -215,7 +215,7 @@ class SafeCreationAdmin(admin.ModelAdmin):
     search_fields = ["=safe__address", "=deployer", "owners"]
 
     def ether_deploy_cost(self, obj: SafeCreation) -> float:
-        return Web3.fromWei(obj.wei_deploy_cost(), "ether")
+        return Web3.from_wei(obj.wei_deploy_cost(), "ether")
 
 
 class SafeCreation2DeployedListFilter(admin.SimpleListFilter):
@@ -258,7 +258,7 @@ class SafeCreation2Admin(admin.ModelAdmin):
     search_fields = ["=safe__address", "owners", "=tx_hash"]
 
     def ether_deploy_cost(self, obj: SafeCreation2) -> float:
-        return Web3.fromWei(obj.wei_estimated_deploy_cost(), "ether")
+        return Web3.from_wei(obj.wei_estimated_deploy_cost(), "ether")
 
     def gas_used(self, obj: SafeCreation2) -> Optional[int]:
         return obj.gas_used()
@@ -330,7 +330,7 @@ class SafeMultisigTxAdmin(admin.ModelAdmin):
 
     def refund_benefit_eth(self, obj: SafeMultisigTx) -> Optional[float]:
         if (refund_benefit := obj.refund_benefit()) is not None:
-            refund_benefit_eth = Web3.fromWei(abs(refund_benefit), "ether") * (
+            refund_benefit_eth = Web3.from_wei(abs(refund_benefit), "ether") * (
                 -1 if refund_benefit < 0 else 1
             )
             return "{:.5f}".format(refund_benefit_eth)

--- a/safe_relay_service/relay/management/commands/test_relay_server.py
+++ b/safe_relay_service/relay/management/commands/test_relay_server.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
             self.main_account.address, "pending"
         )
         main_account_balance = self.w3.eth.get_balance(self.main_account.address)
-        main_account_balance_eth = self.w3.fromWei(main_account_balance, "ether")
+        main_account_balance_eth = self.w3.from_wei(main_account_balance, "ether")
         self.stdout.write(
             self.style.SUCCESS(
                 f"Using {self.main_account.address} as main account with "
@@ -366,7 +366,7 @@ class Command(BaseCommand):
             self.main_account.key,
             safe_address,
             self.ethereum_client.w3.eth.gasPrice,
-            self.w3.toWei(1, "ether"),
+            self.w3.to_wei(1, "ether"),
             nonce=self.main_account_nonce,
         )
         self.main_account_nonce += 1

--- a/safe_relay_service/relay/services/funding_service.py
+++ b/safe_relay_service/relay/services/funding_service.py
@@ -68,7 +68,7 @@ class FundingService:
         if not gas_price:
             gas_price = self.gas_station.get_gas_prices().standard
 
-        if self.max_eth_to_send and value > Web3.toWei(self.max_eth_to_send, "ether"):
+        if self.max_eth_to_send and value > Web3.to_wei(self.max_eth_to_send, "ether"):
             raise EtherLimitExceeded(
                 "%d is bigger than %f" % (value, self.max_eth_to_send)
             )

--- a/safe_relay_service/relay/services/stats_service.py
+++ b/safe_relay_service/relay/services/stats_service.py
@@ -41,7 +41,7 @@ class StatsService:
         :param safe_address:
         :return: `{'token_address': str, 'balance': int}`. For ether, `token_address` is `None`
         """
-        assert Web3.isChecksumAddress(
+        assert Web3.is_checksum_address(
             safe_address
         ), f"Not valid address {safe_address} for getting balances"
 

--- a/safe_relay_service/relay/services/transaction_scan_service.py
+++ b/safe_relay_service/relay/services/transaction_scan_service.py
@@ -241,7 +241,7 @@ class TransactionScanService(ABC):
         """
         assert safe_addresses, "Safe addresses cannot be empty!"
         assert all(
-            [Web3.isChecksumAddress(safe_address) for safe_address in safe_addresses]
+            [Web3.is_checksum_address(safe_address) for safe_address in safe_addresses]
         ), ("A safe address has invalid checksum: %s" % safe_addresses)
 
         parameters = self.get_block_numbers_for_search(safe_addresses)

--- a/safe_relay_service/relay/tasks.py
+++ b/safe_relay_service/relay/tasks.py
@@ -61,8 +61,8 @@ def fund_deployer_task(self, safe_address: str, retry: bool = True) -> None:
     payment = safe_creation.payment
 
     # These asserts just to make sure we are not wasting money
-    assert Web3.isChecksumAddress(safe_address)
-    assert Web3.isChecksumAddress(deployer_address)
+    assert Web3.is_checksum_address(safe_address)
+    assert Web3.is_checksum_address(deployer_address)
     assert mk_contract_address(deployer_address, 0) == safe_address
     assert payment > 0
 
@@ -358,7 +358,7 @@ def deploy_create2_safe_task(self, safe_address: str, retry: bool = True) -> Non
     :param retry: if True, retries are allowed, otherwise don't retry
     """
 
-    assert Web3.isChecksumAddress(safe_address)
+    assert Web3.is_checksum_address(safe_address)
 
     redis = RedisRepository().redis
     lock_name = f"locks:deploy_create2_safe:{safe_address}"

--- a/safe_relay_service/relay/tests/factories.py
+++ b/safe_relay_service/relay/tests/factories.py
@@ -64,7 +64,7 @@ class SafeCreationFactory(DjangoModelFactory):
     tx_hash = factory.Sequence(lambda n: Web3.keccak(n))
     gas = factory.fuzzy.FuzzyInteger(100000, 200000)
     gas_price = factory.fuzzy.FuzzyInteger(
-        Web3.toWei(1, "gwei"), Web3.toWei(20, "gwei")
+        Web3.to_wei(1, "gwei"), Web3.to_wei(20, "gwei")
     )
     payment_token = None
     value = 0
@@ -98,7 +98,7 @@ class SafeCreation2Factory(DjangoModelFactory):
     setup_data = factory.Sequence(lambda n: HexBytes("%x" % (n + 1000)))
     gas_estimated = factory.fuzzy.FuzzyInteger(100000, 200000)
     gas_price_estimated = factory.fuzzy.FuzzyInteger(
-        Web3.toWei(1, "gwei"), Web3.toWei(20, "gwei")
+        Web3.to_wei(1, "gwei"), Web3.to_wei(20, "gwei")
     )
     tx_hash = factory.Sequence(lambda n: Web3.keccak(text="safe-creation-2-%d" % n))
     block_number = None

--- a/safe_relay_service/relay/tests/test_erc20_events_service.py
+++ b/safe_relay_service/relay/tests/test_erc20_events_service.py
@@ -35,20 +35,20 @@ class TestErc20EventsService(SafeTestCaseMixin, TestCase):
         to_tx_hash = self.send_tx(
             erc20_contract.functions.transfer(
                 account_1.address, amount // 2
-            ).buildTransaction({"from": owner_account.address}),
+            ).build_transaction({"from": owner_account.address}),
             owner_account,
         )
         self.send_tx(
             erc20_contract.functions.transfer(
                 account_3.address, amount // 2
-            ).buildTransaction({"from": owner_account.address}),
+            ).build_transaction({"from": owner_account.address}),
             owner_account,
         )
         # `account1` sends `amount // 2` (all) to `account_2`
         from_tx_hash = self.send_tx(
             erc20_contract.functions.transfer(
                 account_2.address, amount // 2
-            ).buildTransaction({"from": account_1.address}),
+            ).build_transaction({"from": account_1.address}),
             account_1,
         )
 

--- a/safe_relay_service/relay/tests/test_funding_service.py
+++ b/safe_relay_service/relay/tests/test_funding_service.py
@@ -18,6 +18,6 @@ class TestFundingService(RelayTestCaseMixin, TestCase):
 
         with self.assertRaises(EtherLimitExceeded):
             self.funding_service.max_eth_to_send = 1
-            self.funding_service.send_eth_to(to, self.w3.toWei(1.1, "ether"))
+            self.funding_service.send_eth_to(to, self.w3.to_wei(1.1, "ether"))
 
         FundingServiceProvider.del_singleton()

--- a/safe_relay_service/relay/tests/test_resend_txs.py
+++ b/safe_relay_service/relay/tests/test_resend_txs.py
@@ -13,7 +13,7 @@ class TestResendTxsCommand(RelayTestCaseMixin, TestCase):
 
         # w3 = self.w3
         # # The balance we will send to the safe
-        # safe_balance = w3.toWei(0.02, "ether")
+        # safe_balance = w3.to_wei(0.02, "ether")
         #
         # # Create Safe
         # accounts = [self.create_account(), self.create_account()]
@@ -76,8 +76,8 @@ class TestResendTxsCommand(RelayTestCaseMixin, TestCase):
         #     safe_multisig_tx.ethereum_tx.tx_hash
         # )
         # self.assertTrue(tx_receipt["status"])
-        # self.assertEqual(w3.toChecksumAddress(tx_receipt["from"]), sender)
-        # self.assertEqual(w3.toChecksumAddress(tx_receipt["to"]), my_safe_address)
+        # self.assertEqual(w3.to_checksum_address(tx_receipt["from"]), sender)
+        # self.assertEqual(w3.to_checksum_address(tx_receipt["to"]), my_safe_address)
         # self.assertEqual(w3.eth.get_balance(to), value)
         #
         # w3.testing.revert(snapshot_id)  # Revert to snapshot in ganache

--- a/safe_relay_service/relay/tests/test_tasks.py
+++ b/safe_relay_service/relay/tests/test_tasks.py
@@ -57,7 +57,7 @@ class TestTasks(RelayTestCaseMixin, TestCase):
         self.send_tx(
             erc20_contract.functions.transfer(
                 safe_address, amount // 2
-            ).buildTransaction({"from": owner_account.address}),
+            ).build_transaction({"from": owner_account.address}),
             owner_account,
         )
 

--- a/safe_relay_service/relay/tests/test_transaction_service.py
+++ b/safe_relay_service/relay/tests/test_transaction_service.py
@@ -34,7 +34,7 @@ class TestTransactionService(RelayTestCaseMixin, TestCase):
         w3 = self.w3
 
         # The balance we will send to the safe
-        safe_balance = w3.toWei(0.02, "ether")
+        safe_balance = w3.to_wei(0.02, "ether")
 
         # Create Safe
         funder_account = self.ethereum_test_account
@@ -119,7 +119,7 @@ class TestTransactionService(RelayTestCaseMixin, TestCase):
         proxy_create_tx = (
             get_paying_proxy_contract(self.w3)
             .constructor(random_master_copy, b"", NULL_ADDRESS, NULL_ADDRESS, 0)
-            .buildTransaction({"from": self.ethereum_test_account.address})
+            .build_transaction({"from": self.ethereum_test_account.address})
         )
         tx_hash = self.ethereum_client.send_unsigned_transaction(
             proxy_create_tx, private_key=self.ethereum_test_account.key
@@ -307,8 +307,8 @@ class TestTransactionService(RelayTestCaseMixin, TestCase):
             safe_multisig_tx.ethereum_tx.tx_hash
         )
         self.assertTrue(tx_receipt["status"])
-        self.assertEqual(w3.toChecksumAddress(tx_receipt["from"]), sender)
-        self.assertEqual(w3.toChecksumAddress(tx_receipt["to"]), my_safe_address)
+        self.assertEqual(w3.to_checksum_address(tx_receipt["from"]), sender)
+        self.assertEqual(w3.to_checksum_address(tx_receipt["to"]), my_safe_address)
         # Changed with EIP1559
         # self.assertGreater(
         #     safe_multisig_tx.ethereum_tx.gas_price, gas_price

--- a/safe_relay_service/relay/tests/test_views.py
+++ b/safe_relay_service/relay/tests/test_views.py
@@ -113,7 +113,7 @@ class TestViews(RelayTestCaseMixin, APITestCase):
     def test_safe_multisig_tx_post(self):
         # Create Safe ------------------------------------------------
         w3 = self.ethereum_client.w3
-        safe_balance = w3.toWei(0.01, "ether")
+        safe_balance = w3.to_wei(0.01, "ether")
         accounts = [self.create_account(), self.create_account()]
         # Signatures must be sorted!
         accounts.sort(key=lambda account: account.address.lower())
@@ -368,7 +368,7 @@ class TestViews(RelayTestCaseMixin, APITestCase):
     def test_safe_multisig_tx_post_gas_token(self):
         # Create Safe ------------------------------------------------
         w3 = self.ethereum_client.w3
-        safe_balance = w3.toWei(0.01, "ether")
+        safe_balance = w3.to_wei(0.01, "ether")
         owner_account = self.create_account()
         owner = owner_account.address
         threshold = 1
@@ -513,7 +513,7 @@ class TestViews(RelayTestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        initial_funding = self.w3.toWei(0.0001, "ether")
+        initial_funding = self.w3.to_wei(0.0001, "ether")
         to, _ = get_eth_address_with_key()
         data = {"to": to, "value": initial_funding // 2, "data": "0x", "operation": 1}
 
@@ -586,7 +586,7 @@ class TestViews(RelayTestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        initial_funding = self.w3.toWei(0.0001, "ether")
+        initial_funding = self.w3.to_wei(0.0001, "ether")
 
         safe = self.deploy_test_safe(
             number_owners=3, threshold=2, initial_funding_wei=initial_funding

--- a/safe_relay_service/relay/tests/test_views_v2.py
+++ b/safe_relay_service/relay/tests/test_views_v2.py
@@ -68,8 +68,8 @@ class TestViewsV2(RelayTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_json = response.json()
         safe_address = response_json["safe"]
-        self.assertTrue(Web3.isChecksumAddress(safe_address))
-        self.assertTrue(Web3.isChecksumAddress(response_json["paymentReceiver"]))
+        self.assertTrue(Web3.is_checksum_address(safe_address))
+        self.assertTrue(Web3.is_checksum_address(response_json["paymentReceiver"]))
         self.assertEqual(response_json["paymentToken"], NULL_ADDRESS)
         self.assertEqual(
             int(response_json["payment"]),
@@ -129,8 +129,8 @@ class TestViewsV2(RelayTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_json = response.json()
         safe_address = response_json["safe"]
-        self.assertTrue(Web3.isChecksumAddress(safe_address))
-        self.assertTrue(Web3.isChecksumAddress(response_json["paymentReceiver"]))
+        self.assertTrue(Web3.is_checksum_address(safe_address))
+        self.assertTrue(Web3.is_checksum_address(response_json["paymentReceiver"]))
         self.assertEqual(response_json["paymentToken"], NULL_ADDRESS)
         self.assertEqual(response_json["payment"], str(fixed_creation_cost))
         self.assertGreater(int(response_json["gasEstimated"]), 0)
@@ -164,8 +164,8 @@ class TestViewsV2(RelayTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_json = response.json()
         safe_address = response_json["safe"]
-        self.assertTrue(Web3.isChecksumAddress(safe_address))
-        self.assertTrue(Web3.isChecksumAddress(response_json["paymentReceiver"]))
+        self.assertTrue(Web3.is_checksum_address(safe_address))
+        self.assertTrue(Web3.is_checksum_address(response_json["paymentReceiver"]))
         self.assertEqual(response_json["paymentToken"], payment_token)
         self.assertEqual(
             int(response_json["payment"]),
@@ -204,7 +204,7 @@ class TestViewsV2(RelayTestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        initial_funding = self.w3.toWei(0.0001, "ether")
+        initial_funding = self.w3.to_wei(0.0001, "ether")
         to = Account.create().address
         data = {"to": to, "value": initial_funding // 2, "data": "0x", "operation": 1}
 

--- a/safe_relay_service/relay/tests/test_views_v3.py
+++ b/safe_relay_service/relay/tests/test_views_v3.py
@@ -66,8 +66,8 @@ class TestViewsV3(RelayTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_json = response.json()
         safe_address = response_json["safe"]
-        self.assertTrue(Web3.isChecksumAddress(safe_address))
-        self.assertTrue(Web3.isChecksumAddress(response_json["paymentReceiver"]))
+        self.assertTrue(Web3.is_checksum_address(safe_address))
+        self.assertTrue(Web3.is_checksum_address(response_json["paymentReceiver"]))
         self.assertEqual(response_json["paymentToken"], NULL_ADDRESS)
         self.assertEqual(
             int(response_json["payment"]),
@@ -125,8 +125,8 @@ class TestViewsV3(RelayTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_json = response.json()
         safe_address = response_json["safe"]
-        self.assertTrue(Web3.isChecksumAddress(safe_address))
-        self.assertTrue(Web3.isChecksumAddress(response_json["paymentReceiver"]))
+        self.assertTrue(Web3.is_checksum_address(safe_address))
+        self.assertTrue(Web3.is_checksum_address(response_json["paymentReceiver"]))
         self.assertEqual(response_json["paymentToken"], NULL_ADDRESS)
         self.assertEqual(response_json["payment"], str(fixed_creation_cost))
         self.assertGreater(int(response_json["gasEstimated"]), 0)
@@ -160,8 +160,8 @@ class TestViewsV3(RelayTestCaseMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_json = response.json()
         safe_address = response_json["safe"]
-        self.assertTrue(Web3.isChecksumAddress(safe_address))
-        self.assertTrue(Web3.isChecksumAddress(response_json["paymentReceiver"]))
+        self.assertTrue(Web3.is_checksum_address(safe_address))
+        self.assertTrue(Web3.is_checksum_address(response_json["paymentReceiver"]))
         self.assertEqual(response_json["paymentToken"], payment_token)
         self.assertEqual(
             int(response_json["payment"]),

--- a/safe_relay_service/relay/validators.py
+++ b/safe_relay_service/relay/validators.py
@@ -4,7 +4,7 @@ from web3 import Web3
 
 
 def validate_checksumed_address(address):
-    if not Web3.isChecksumAddress(address):
+    if not Web3.is_checksum_address(address):
         raise ValidationError(
             "%(address)s is not a valid ethereum address",
             params={"address": address},

--- a/safe_relay_service/relay/views.py
+++ b/safe_relay_service/relay/views.py
@@ -215,7 +215,7 @@ class SafeView(APIView):
         """
         Get status of the safe
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         safe_info = SafeCreationServiceProvider().retrieve_safe_info(address)
@@ -240,7 +240,7 @@ class SafeBalanceView(APIView):
         """
         Get status of the safe
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         else:
             try:
@@ -271,7 +271,7 @@ class SafeSignalView(APIView):
         """
         Get status of the safe creation
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         else:
             try:
@@ -294,7 +294,7 @@ class SafeSignalView(APIView):
         """
         Force check of a safe balance to start the safe creation
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         else:
             try:
@@ -324,7 +324,7 @@ class SafeMultisigTxEstimateView(CreateAPIView):
         """
         Estimates a Safe Multisig Transaction. `operational_gas` and `data_gas` are deprecated, use `base_gas` instead
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         request.data["safe"] = address
@@ -366,7 +366,7 @@ class SafeMultisigTxEstimatesView(CreateAPIView):
         Estimates a Safe Multisig Transaction for all tokens supported. `operational_gas` and `data_gas`
         are deprecated, use `base_gas` instead
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         request.data["safe"] = address
@@ -405,7 +405,7 @@ class SafeListApiView(ListAPIView):
         }
     )
     def get(self, request, address):
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         else:
             try:
@@ -444,7 +444,7 @@ class SafeMultisigTxView(SafeListApiView):
         """
         Send a Safe Multisig Transaction
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         request.data["safe"] = address

--- a/safe_relay_service/relay/views_v2.py
+++ b/safe_relay_service/relay/views_v2.py
@@ -137,7 +137,7 @@ class SafeMultisigTxEstimateView(CreateAPIView):
         """
         Estimates a Safe Multisig Transaction. `operational_gas` and `data_gas` are deprecated, use `base_gas` instead
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         request.data["safe"] = address
@@ -175,7 +175,7 @@ class SafeSignalView(APIView):
         """
         Get status of the safe creation
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         else:
             try:
@@ -196,7 +196,7 @@ class SafeSignalView(APIView):
         """
         Force check of a safe balance to start the safe creation
         """
-        if not Web3.isChecksumAddress(address):
+        if not Web3.is_checksum_address(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         else:
             try:

--- a/safe_relay_service/tokens/management/commands/add_token.py
+++ b/safe_relay_service/tokens/management/commands/add_token.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         ethereum_client = EthereumClientProvider()
 
         for token_address in tokens:
-            token_address = ethereum_client.w3.toChecksumAddress(token_address)
+            token_address = ethereum_client.w3.to_checksum_address(token_address)
             try:
                 token = Token.objects.get(address=token_address)
                 self.stdout.write(

--- a/safe_relay_service/tokens/tests/test_models.py
+++ b/safe_relay_service/tokens/tests/test_models.py
@@ -18,32 +18,32 @@ class TestModels(TestCase):
     def test_token_calculate_payment(self):
         token = TokenFactory(fixed_eth_conversion=0.1)
         self.assertEqual(
-            token.calculate_payment(Web3.toWei(1, "ether")), Web3.toWei(10, "ether")
+            token.calculate_payment(Web3.to_wei(1, "ether")), Web3.to_wei(10, "ether")
         )
 
         token = TokenFactory(fixed_eth_conversion=1.0)
         self.assertEqual(
-            token.calculate_payment(Web3.toWei(1, "ether")), Web3.toWei(1, "ether")
+            token.calculate_payment(Web3.to_wei(1, "ether")), Web3.to_wei(1, "ether")
         )
 
         token = TokenFactory(fixed_eth_conversion=2.0)
         self.assertEqual(
-            token.calculate_payment(Web3.toWei(1, "ether")), Web3.toWei(0.5, "ether")
+            token.calculate_payment(Web3.to_wei(1, "ether")), Web3.to_wei(0.5, "ether")
         )
 
         token = TokenFactory(fixed_eth_conversion=10.0)
         self.assertEqual(
-            token.calculate_payment(Web3.toWei(1, "ether")), Web3.toWei(0.1, "ether")
+            token.calculate_payment(Web3.to_wei(1, "ether")), Web3.to_wei(0.1, "ether")
         )
 
         token = TokenFactory(fixed_eth_conversion=0.6512)
         self.assertEqual(
-            token.calculate_payment(Web3.toWei(1.23, "ether")), 1888820638820638720
+            token.calculate_payment(Web3.to_wei(1.23, "ether")), 1888820638820638720
         )
 
         token = TokenFactory(fixed_eth_conversion=1.0, decimals=17)
         self.assertEqual(
-            token.calculate_payment(Web3.toWei(1, "ether")), Web3.toWei(0.1, "ether")
+            token.calculate_payment(Web3.to_wei(1, "ether")), Web3.to_wei(0.1, "ether")
         )
 
     @mock.patch.object(Kraken, "get_price", return_value=3.8, autospec=True)


### PR DESCRIPTION
- Update precommit
- Bump packaging from 22.0 to 23.0
- Bump pytest from 7.2.0 to 7.2.1
- Bump safe-eth-py[django] from 4.8.2 to 4.9.3
- Bump django-stubs from 1.13.1 to 1.14.0
- Bump safe-eth-py[django] from 4.9.3 to 5.0.1
- Bump numpy from 1.24.1 to 1.24.2 (#536)
- Bump django from 4.1.5 to 4.1.6
- Bump coverage from 7.0.0 to 7.1.0
- Bump requests from 2.28.1 to 2.28.2
- Bump redis from 4.4.2 to 4.5.1
- Bump djangorestframework-camel-case from 1.3.0 to 1.4.2
- Bump faker from 15.3.4 to 17.0.0
- Bump django from 4.1.6 to 4.1.7
- Fix tests
- Update precommit
- Add configuration for automatic releases
- Format files with new black version
- Bump safe-eth-py[django] from 5.0.1 to 5.0.2
- Bump django-stubs from 1.14.0 to 1.16.0
- Bump coverage from 7.1.0 to 7.2.2
- Fix the estimate tx gas price function (#554)
- Bump faker from 17.0.0 to 17.6.0
- Bump drf-yasg[validation] from 1.21.4 to 1.21.5
- Set version 4.3.0
- Bump django-environ from 0.9.0 to 0.10.0
- Bump redis from 4.5.1 to 4.5.3
- Bump pytest from 7.2.1 to 7.2.2
- Bump faker from 17.6.0 to 18.3.1
- Add hiredis
- Don't allow zero address refund receiver
- Bump redis from 4.5.3 to 4.5.4
- Bump django-celery-beat from 2.4.0 to 2.5.0
- Update safe-eth-py and Web3
